### PR TITLE
Redirect power module reading to specific device power monitor PVs

### DIFF
--- a/ipmiMgrApp/Db/Makefile
+++ b/ipmiMgrApp/Db/Makefile
@@ -16,6 +16,7 @@ DB += sensor_ai_alias.db
 DB += fru_common_alias.db
 DB += fru_cu_common_alias.db
 DB += system_common_alias.db
+DB += power_mngr.db
 
 #Modules
 DB += cooling_unit.db

--- a/ipmiMgrApp/Db/afcv3.substitutions
+++ b/ipmiMgrApp/Db/afcv3.substitutions
@@ -33,6 +33,12 @@ file "fru_common_alias.db"
             { $(id) , $(fruid) }
 }
 
+file "power_mngr.db"
+{
+    pattern { id    , power_channel }
+            { $(id) , $(power_channel) }
+}
+
 file "sensor_ai_alias.db"
 {
     pattern { attr            , sensinst    , type    , fruid        , prefix }

--- a/ipmiMgrApp/Db/afcv4.substitutions
+++ b/ipmiMgrApp/Db/afcv4.substitutions
@@ -19,6 +19,12 @@ file "fru_common_alias.db"
             { $(id) , $(fruid) }
 }
 
+file "power_mngr.db"
+{
+    pattern { id    , power_channel }
+            { $(id) , $(power_channel) }
+}
+
 file "sensor_ai_alias.db"
 {
     pattern { attr            , sensinst    , type    , fruid        , prefix }

--- a/ipmiMgrApp/Db/cooling_unit.substitutions
+++ b/ipmiMgrApp/Db/cooling_unit.substitutions
@@ -35,6 +35,12 @@ file "fru_common_alias.db"
             { $(id) , $(fruid) }
 }
 
+file "power_mngr.db"
+{
+    pattern { id    , power_channel }
+            { $(id) , $(power_channel) }
+}
+
 file "sensor_ai_alias.db"
 {
     pattern { attr         , sensinst    , type    , fruid    , prefix }

--- a/ipmiMgrApp/Db/fru_common_alias.template
+++ b/ipmiMgrApp/Db/fru_common_alias.template
@@ -23,5 +23,3 @@ alias("$(dev):$(id)$(unit):PSN", "$(P)$(R)$(id)ProdSN-Cte")
 alias("$(dev):$(id)$(unit):PPARTNUMBER", "$(P)$(R)$(id)ProdPN-Cte")
 
 alias("$(dev):$(id)$(unit):POWERCTL", "$(P)$(R)$(id)PowerCtl-Sel")
-
-alias("$(dev):$(id)$(unit):PWR", "$(P)$(R)$(id)Pwr")

--- a/ipmiMgrApp/Db/microtca_bpm_crate.substitutions
+++ b/ipmiMgrApp/Db/microtca_bpm_crate.substitutions
@@ -27,37 +27,37 @@ file "power_module.db"
 
 file "mch_nat.db"
 {
-    pattern { id   }
-            { MCH  }
+    pattern { id   , power_channel}
+            { MCH  , 01}
 }
 
 file "cooling_unit.db"
 {
-    pattern { id    , fruid }
-            { CUTop , 40    }
-            { CUBot , 41    }
+    pattern { id    , fruid, power_channel }
+            { CUTop , 40   , 03}
+            { CUBot , 41   , 04}
 }
 
 file "afcv3.db"
 {
-    pattern { id    , fruid }
-            { AMC1  , 5     }
-            { AMC3  , 7     }
-            { AMC4  , 8     }
-            { AMC5  , 9     }
-            { AMC6  , 10    }
-            { AMC7  , 11    }
-            { AMC8  , 12    }
-            { AMC9  , 13    }
-            { AMC10 , 14    }
-            { AMC11 , 15    }
-            { AMC12 , 16    }
+    pattern { id    , fruid, power_channel }
+            { AMC1  , 5    , 05}
+            { AMC3  , 7    , 07}
+            { AMC4  , 8    , 08}
+            { AMC5  , 9    , 09}
+            { AMC6  , 10   , 10}
+            { AMC7  , 11   , 11}
+            { AMC8  , 12   , 12}
+            { AMC9  , 13   , 13}
+            { AMC10 , 14   , 14}
+            { AMC11 , 15   , 15}
+            { AMC12 , 16   , 16}
 }
 
 file "afcv4.db"
 {
-    pattern { id    , fruid }
-            { AMC2  , 6     }
+    pattern { id    , fruid, power_channel }
+            { AMC2  , 6    , 06}
 }
 
 file "rtm_8sfp.db"

--- a/ipmiMgrApp/Db/power_mngr.template
+++ b/ipmiMgrApp/Db/power_mngr.template
@@ -1,0 +1,1 @@
+alias("$(P)$(R)PM2CurrCh$(power_channel)-Mon", "$(P)$(R)$(id)Pwr")


### PR DESCRIPTION
Since the device itself can't read the power consumption, this information has to come from the power module specific channel that is related to each device. The power module used is PM2 because PM4 is just used for redundancy and to replace the PM2 in case of some failure, and don't have any device connected to it's channels.