### PR TITLE
Remove sensinst from PV name.

### DIFF
--- a/iocBoot/iocIpmiMgr/stIpmiMgr.cmd
+++ b/iocBoot/iocIpmiMgr/stIpmiMgr.cmd
@@ -8,6 +8,8 @@ epicsEnvSet("TOP", "../..")
 dbLoadDatabase("$(TOP)/dbd/ipmiMgr.dbd",0,0)
 ipmiMgr_registerRecordDeviceDriver pdbbase
 
+var dbRecordsOnceOnly 1
+
 ## Initialize connection to MCH
 drvAsynIPPortConfigure ("$(PORT)","$(IPADDR):623 udp",0,0,0)
 mchInit("$(PORT)")

--- a/ipmiMgrApp/Db/cooling_unit.substitutions
+++ b/ipmiMgrApp/Db/cooling_unit.substitutions
@@ -42,7 +42,7 @@ file "sensor_ai_alias.db"
             { LM75Temp2    , 2           , 1       , $(fruid) , $(id)  }
             { 3V3          , 1           , 2       , $(fruid) , $(id)  }
             { 12V          , 2           , 2       , $(fruid) , $(id)  }
-            { 12V          , 3           , 2       , $(fruid) , $(id)  }
+            { 12V_1        , 3           , 2       , $(fruid) , $(id)  }
             { Fan1         , 1           , 4       , $(fruid) , $(id)  }
             { Fan2         , 2           , 4       , $(fruid) , $(id)  }
             { Fan3         , 3           , 4       , $(fruid) , $(id)  }

--- a/ipmiMgrApp/Db/sensor_ai_alias.template
+++ b/ipmiMgrApp/Db/sensor_ai_alias.template
@@ -1,5 +1,5 @@
 include "sensor_ai.db"
 
-alias("$(dev):$(prefix)$(attr)$(sensinst)", "$(P)$(R)$(prefix)$(attr)$(sensinst)-Mon")
+alias("$(dev):$(prefix)$(attr)$(sensinst)", "$(P)$(R)$(prefix)$(attr)-Mon")
 
-alias("$(dev):$(prefix)$(attr)$(sensinst)P", "$(P)$(R)$(prefix)$(attr)$(sensinst)Prs-Sts")
+alias("$(dev):$(prefix)$(attr)$(sensinst)P", "$(P)$(R)$(prefix)$(attr)Prs-Sts")


### PR DESCRIPTION
We were using `sensinst` to avoid duplicated PV names, but it makes a big mess on sensors that have its indexing on its `attr`. So, it's better to solve the duplicated names on the `attr` fields.