### PR TITLE
Remove unsupported MState read PV.

### DIFF
--- a/ipmiMgrApp/Db/fru_common_alias.template
+++ b/ipmiMgrApp/Db/fru_common_alias.template
@@ -2,8 +2,6 @@ include "fru_common.db"
 
 alias("$(dev):$(id)$(unit):P", "$(P)$(R)$(id)Prs-Sts")
 
-alias("$(dev):$(id)$(unit):MSTATE", "$(P)$(R)$(id)MState-Sts")
-
 alias("$(dev):$(id)$(unit):FRUID", "$(P)$(R)$(id)FruId-Cte")
 
 alias("$(dev):$(id)$(unit):BMANUF", "$(P)$(R)$(id)BoardManuf-Cte")


### PR DESCRIPTION
According to NAT's support team, is it only possible to read the FRUs MState through the MCH CLI, and there is no IPMI commando to achieve this. In this way, this record is no longer supported.