### PR TITLE
Fix prefix substitution issue for `mch_nat` devices.

### DIFF
--- a/ipmiMgrApp/Db/mch_nat.substitutions
+++ b/ipmiMgrApp/Db/mch_nat.substitutions
@@ -26,24 +26,24 @@
 
 file "mch_base.db"
 {
-    pattern { dev        , fruid }
-            { $(dev)_Base, 3     }
+    pattern { dev            , fruid }
+            { $(pre_dev)_Base, 3     }
 }
 
 file "mch_clk_switch.db"
 {
-    pattern { dev         , fruid }
-            { $(dev)_ClkSw, 60    }
+    pattern { dev             , fruid }
+            { $(pre_dev)_ClkSw, 60    }
 }
 
 file "mch_pci_hub.db"
 {
-    pattern { dev           , fruid }
-            { $(dev)_PCI_Hub, 61    }
+    pattern { dev               , fruid }
+            { $(pre_dev)_PCI_Hub, 61    }
 }
 
 file "rtm_cpu.db"
 {
     pattern { dev           , fruid }
-            { $(dev)_RTM_CPU, 64    }
+            { $(pre_dev)_RTM_CPU, 64    }
 }

--- a/ipmiMgrApp/Db/microtca_bpm_crate.substitutions
+++ b/ipmiMgrApp/Db/microtca_bpm_crate.substitutions
@@ -27,8 +27,8 @@ file "power_module.db"
 
 file "mch_nat.db"
 {
-    pattern { dev, power_channel }
-            { MCH, 01            }
+    pattern { pre_dev, power_channel }
+            { MCH    , 01            }
 }
 
 file "cooling_unit.db"


### PR DESCRIPTION
Replaced `${dev}` with `${pre_dev}` in MCH devices prefix substitution to prevent suffix duplication. The previous substitution expanded the prefix twice, leading to incorrect device names. This change ensures proper name handling.